### PR TITLE
商品情報編集機能の実装

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,5 +1,5 @@
 class ItemsController < ApplicationController
-  before_action :authenticate_user!, only: :new
+  before_action :authenticate_user!, except: [:index, :show]
 
   def index
     @items = Item.all.order(created_at: :desc)
@@ -15,6 +15,20 @@ class ItemsController < ApplicationController
       redirect_to root_path
     else
       render :new
+    end
+  end
+
+  def edit
+    @item = Item.find(params[:id])
+    redirect_to root_path unless current_user.id == @item.user_id
+  end
+
+  def update
+    @item = Item.find(params[:id])
+    if @item.update(item_params)
+      redirect_to item_path
+    else
+      render :edit
     end
   end
 

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,5 +1,6 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!, except: [:index, :show]
+  before_action :set_item, only: [:edit, :update, :show]
 
   def index
     @items = Item.all.order(created_at: :desc)
@@ -19,12 +20,10 @@ class ItemsController < ApplicationController
   end
 
   def edit
-    @item = Item.find(params[:id])
     redirect_to root_path unless current_user.id == @item.user_id
   end
 
   def update
-    @item = Item.find(params[:id])
     if @item.update(item_params)
       redirect_to item_path
     else
@@ -33,13 +32,16 @@ class ItemsController < ApplicationController
   end
 
   def show
-    @item = Item.find(params[:id])
   end
 
   private
 
   def item_params
     params.require(:item).permit(:name, :price, :description, :item_condition_id, :shipping_cost_id, :shipping_days_id, :prefecture_id, :category_id, :image).merge(user_id: current_user.id)
+  end
+
+  def set_item
+    @item = Item.find(params[:id])
   end
 
 end

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -8,9 +8,9 @@ app/assets/stylesheets/items/new.css %>
     <div class="items-sell-main">
       <h2 class="items-sell-title">商品の情報を入力</h2>
       <%= form_with model: @item, local: true do |f| %>
-        <%# インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
+        
         <%= render 'shared/error_messages', object: f.object %>
-        <%# //インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
+        
 
         <%# 商品画像 %>
         <div class="img-upload">
@@ -140,7 +140,7 @@ app/assets/stylesheets/items/new.css %>
            <%# 下部ボタン %>
         <div class="sell-btn-contents">
            <%= f.submit "変更する",class:"sell-btn" %>
-           <%=link_to 'もどる', root_path, class:"back-btn" %>
+           <%=link_to 'もどる', item_path, class:"back-btn" %>
         </div>
           <%# /下部ボタン %>
       <% end %>

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -2,150 +2,149 @@
 app/assets/stylesheets/items/new.css %>
 
 <div class="items-sell-contents">
-  <header class="items-sell-header">
-    <%= link_to image_tag('furima-logo-color.png' , size: '185x50'), "/" %>
-  </header>
-  <div class="items-sell-main">
-    <h2 class="items-sell-title">商品の情報を入力</h2>
-    <%= form_with local: true do |f| %>
+    <header class="items-sell-header">
+      <%= link_to image_tag('furima-logo-color.png' , size: '185x50'), "/" %>
+    </header>
+    <div class="items-sell-main">
+      <h2 class="items-sell-title">商品の情報を入力</h2>
+      <%= form_with model: @item, local: true do |f| %>
+        <%# インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
+        <%= render 'shared/error_messages', object: f.object %>
+        <%# //インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
 
-    <%# インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
-    <%# render 'shared/error_messages', model: f.object %>
-    <%# //インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
-
-    <%# 商品画像 %>
-    <div class="img-upload">
-      <div class="weight-bold-text">
-        商品画像
-        <span class="indispensable">必須</span>
-      </div>
-      <div class="click-upload">
-        <p>
-          クリックしてファイルをアップロード
-        </p>
-        <%= f.file_field :hoge, id:"item-image" %>
-      </div>
-    </div>
-    <%# /商品画像 %>
-    <%# 商品名と商品説明 %>
-    <div class="new-items">
-      <div class="weight-bold-text">
-        商品名
-        <span class="indispensable">必須</span>
-      </div>
-      <%= f.text_area :hoge, class:"items-text", id:"item-name", placeholder:"商品名（必須 40文字まで)", maxlength:"40" %>
-      <div class="items-explain">
-        <div class="weight-bold-text">
-          商品の説明
-          <span class="indispensable">必須</span>
-        </div>
-        <%= f.text_area :hoge, class:"items-text", id:"item-info", placeholder:"商品の説明（必須 1,000文字まで）（色、素材、重さ、定価、注意点など）例）2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。あわせやすいのでおすすめです。" ,rows:"7" ,maxlength:"1000" %>
-      </div>
-    </div>
-    <%# /商品名と商品説明 %>
-
-    <%# 商品の詳細 %>
-    <div class="items-detail">
-      <div class="weight-bold-text">商品の詳細</div>
-      <div class="form">
-        <div class="weight-bold-text">
-          カテゴリー
-          <span class="indispensable">必須</span>
-        </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-category"}) %>
-        <div class="weight-bold-text">
-          商品の状態
-          <span class="indispensable">必須</span>
-        </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-sales-status"}) %>
-      </div>
-    </div>
-    <%# /商品の詳細 %>
-
-    <%# 配送について %>
-    <div class="items-detail">
-      <div class="weight-bold-text question-text">
-        <span>配送について</span>
-        <a class="question" href="#">?</a>
-      </div>
-      <div class="form">
-        <div class="weight-bold-text">
-          配送料の負担
-          <span class="indispensable">必須</span>
-        </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-shipping-fee-status"}) %>
-        <div class="weight-bold-text">
-          発送元の地域
-          <span class="indispensable">必須</span>
-        </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-prefecture"}) %>
-        <div class="weight-bold-text">
-          発送までの日数
-          <span class="indispensable">必須</span>
-        </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-scheduled-delivery"}) %>
-      </div>
-    </div>
-    <%# /配送について %>
-
-    <%# 販売価格 %>
-    <div class="sell-price">
-      <div class="weight-bold-text question-text">
-        <span>販売価格<br>(¥300〜9,999,999)</span>
-        <a class="question" href="#">?</a>
-      </div>
-      <div>
-        <div class="price-content">
-          <div class="price-text">
-            <span>価格</span>
+        <%# 商品画像 %>
+        <div class="img-upload">
+          <div class="weight-bold-text">
+            商品画像
             <span class="indispensable">必須</span>
           </div>
-          <span class="sell-yen">¥</span>
-          <%= f.text_field :hoge, class:"price-input", id:"item-price", placeholder:"例）300" %>
+          <div class="click-upload">
+            <p>
+              クリックしてファイルをアップロード
+            </p>
+            <%= f.file_field :image, id:"item-image" %>
+          </div>
         </div>
-        <div class="price-content">
-          <span>販売手数料 (10%)</span>
-          <span>
-            <span id='add-tax-price'></span>円
-          </span>
+          <%# /商品画像 %>
+          <%# 商品名と商品説明 %>
+        <div class="new-items">
+          <div class="weight-bold-text">
+            商品名
+            <span class="indispensable">必須</span>
+          </div>
+          <%= f.text_area :name, class:"items-text", id:"item-name", placeholder:"商品名（必須 40文字まで)", maxlength:"40" %>
+          <div class="items-explain">
+            <div class="weight-bold-text">
+              商品の説明
+              <span class="indispensable">必須</span>
+            </div>
+            <%= f.text_area :description, class:"items-text", id:"item-info", placeholder:"商品の説明（必須 1,000文字まで）（色、素材、重さ、定価、注意点など）例）2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。あわせやすいのでおすすめです。" ,rows:"7" ,maxlength:"1000" %>
+          </div>
         </div>
-        <div class="price-content">
-          <span>販売利益</span>
-          <span>
-            <span id='profit'></span>円
-          </span>
-        </div>
-      </div>
-    </div>
-    <%# /販売価格 %>
+        <%# /商品名と商品説明 %>
 
-    <%# 注意書き %>
-    <div class="caution">
-      <p class="sentence">
-        <a href="#">禁止されている出品、</a>
-        <a href="#">行為</a>
-        を必ずご確認ください。
-      </p>
-      <p class="sentence">
-        またブランド品でシリアルナンバー等がある場合はご記載ください。
-        <a href="#">偽ブランドの販売</a>
-        は犯罪であり処罰される可能性があります。
-      </p>
-      <p class="sentence">
-        また、出品をもちまして
-        <a href="#">加盟店規約</a>
-        に同意したことになります。
-      </p>
+        <%# 商品の詳細 %>
+        <div class="items-detail">
+          <div class="weight-bold-text">商品の詳細</div>
+            <div class="form">
+             <div class="weight-bold-text">
+               カテゴリー
+               <span class="indispensable">必須</span>
+             </div>
+             <%= f.collection_select(:category_id, Category.all, :id, :name, {}, {class:"select-box", id:"item-category"}) %>
+             <div class="weight-bold-text">
+               商品の状態
+               <span class="indispensable">必須</span>
+             </div>
+             <%= f.collection_select(:item_condition_id, ItemCondition.all, :id, :name, {}, {class:"select-box", id:"item-sales-status"}) %>
+           </div>
+          </div>
+          <%# /商品の詳細 %>
+
+          <%# 配送について %>
+          <div class="items-detail">
+            <div class="weight-bold-text question-text">
+              <span>配送について</span>
+              <a class="question" href="#">?</a>
+            </div>
+            <div class="form">
+              <div class="weight-bold-text">
+                 配送料の負担
+                <span class="indispensable">必須</span>
+              </div>
+              <%= f.collection_select(:shipping_cost_id, ShippingCost.all, :id, :name, {}, {class:"select-box", id:"item-shipping-fee-status"}) %>
+              <div class="weight-bold-text">
+                発送元の地域
+                <span class="indispensable">必須</span>
+              </div>
+              <%= f.collection_select(:prefecture_id, Prefecture.all, :id, :name, {}, {class:"select-box", id:"item-prefecture"}) %>
+              <div class="weight-bold-text">
+                発送までの日数
+                <span class="indispensable">必須</span>
+              </div>
+              <%= f.collection_select(:shipping_days_id, ShippingDays.all, :id, :name, {}, {class:"select-box", id:"item-scheduled-delivery"}) %>
+            </div>
+          </div>
+          <%# /配送について %>
+
+          <%# 販売価格 %>
+          <div class="sell-price">
+            <div class="weight-bold-text question-text">
+              <span>販売価格<br>(¥300〜9,999,999)</span>
+              <a class="question" href="#">?</a>
+            </div>
+            <div>
+               <div class="price-content">
+                 <div class="price-text">
+                  <span>価格</span>
+                  <span class="indispensable">必須</span>
+                 </div>
+                  <span class="sell-yen">¥</span>
+                  <%= f.text_field :price, class:"price-input", id:"item-price", placeholder:"例）300" %>
+               </div>
+               <div class="price-content">
+                <span>販売手数料 (10%)</span>
+                <span>
+                  <span id='add-tax-price'></span>円
+                </span>
+               </div>
+               <div class="price-content">
+                <span>販売利益</span>
+                <span>
+                   <span id='profit'></span>円
+                </span>
+               </div>
+            </div>
+        </div>
+          <%# /販売価格 %>
+
+           <%# 注意書き %>
+        <div class="caution">
+             <p class="sentence">
+              <a href="#">禁止されている出品、</a>
+              <a href="#">行為</a>
+              を必ずご確認ください。
+             </p>
+             <p class="sentence">
+              またブランド品でシリアルナンバー等がある場合はご記載ください。
+               <a href="#">偽ブランドの販売</a>
+              は犯罪であり処罰される可能性があります。
+             </p>
+             <p class="sentence">
+              また、出品をもちまして
+              <a href="#">加盟店規約</a>
+               に同意したことになります。
+             </p>
+        </div>
+           <%# /注意書き %>
+           <%# 下部ボタン %>
+        <div class="sell-btn-contents">
+           <%= f.submit "変更する",class:"sell-btn" %>
+           <%=link_to 'もどる', root_path, class:"back-btn" %>
+        </div>
+          <%# /下部ボタン %>
+      <% end %>
     </div>
-    <%# /注意書き %>
-    <%# 下部ボタン %>
-    <div class="sell-btn-contents">
-      <%= f.submit "変更する" ,class:"sell-btn" %>
-      <%=link_to 'もどる', "#", class:"back-btn" %>
-    </div>
-    <%# /下部ボタン %>
-  </div>
-  <% end %>
 
   <footer class="items-sell-footer">
     <ul class="menu">

--- a/app/views/items/new.html.erb
+++ b/app/views/items/new.html.erb
@@ -134,7 +134,7 @@
           <%# /注意書き %>
           <%# 下部ボタン %>
           <div class="sell-btn-contents">
-            <%= f.submit "出品する" ,class:"sell-btn" %>
+            <%= f.submit "出品する", class:"sell-btn" %>
             <%=link_to 'もどる', root_path, class:"back-btn" %>
           </div>
           <%# /下部ボタン %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -27,7 +27,7 @@
 
 <% if user_signed_in? %>
     <% if current_user.id == @item.user_id %>
-    <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
+    <%= link_to "商品の編集", edit_item_path(@item.id), method: :get, class: "item-red-btn" %>
     <p class="or-text">or</p>
     <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
     <% else %>


### PR DESCRIPTION
What
商品情報編集画面の作成

Why
商品情報編集機能の実装のため


ログイン状態の出品者は、商品情報編集ページに遷移できる動画 https://gyazo.com/6bceb54968660c8a070d41f72841123a

必要な情報を適切に入力して「更新する」ボタンを押すと、商品の情報を編集できる動画
https://gyazo.com/6b8e531fc604abb9f416f0e11e4c1792 
入力に問題がある状態で「変更する」ボタンが押された場合、情報は保存されず、編集ページに戻りエラーメッセージが表示される動画
https://gyazo.com/d64ddf4e5d7804281abf68df8bda9b64

何も編集せずに「更新する」ボタンを押しても、画像無しの商品にならない動画
https://gyazo.com/027cefec3c07a2687c14d2c5833dc8b5

ログイン状態の場合でも、URLを直接入力して自身が出品していない商品の商品情報編集ページへ遷移しようとすると、商品の販売状況に関わらずトップページに遷移する動画
https://gyazo.com/f250922f9c93c764cc3810ba0a1509ad

ログアウト状態の場合は、URLを直接入力して商品情報編集ページへ遷移しようとすると、商品の販売状況に関わらずログインページに遷移する動画
https://gyazo.com/4487b2e65733ba1c94dcf09ab1639f99

 商品名やカテゴリーの情報など、すでに登録されている商品情報は商品情報編集画面を開いた時点で表示される動画（商品画像・販売手数料・販売利益に関しては、表示されない状態で良い）
https://gyazo.com/ee0d105e829754336f0a9b31aa3b8710